### PR TITLE
Support multi-container deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This pipeline will update the `my-deployment` deployment with the image tagged `
             container: my-container
             tag: ${DRONE_COMMIT_SHA:8}
 
-Deploying several new containers, eg in a scheduler-worker setup. Make sure your container `name` in your manifest is the same for each pod.
+Deploying containers across several deployments, eg in a scheduler-worker setup. Make sure your container `name` in your manifest is the same for each pod.
     
     pipeline:
         deploy:
@@ -23,6 +23,18 @@ Deploying several new containers, eg in a scheduler-worker setup. Make sure your
             repo: myorg/myrepo
             container: my-container
             tag: ${DRONE_COMMIT_SHA:8}
+
+Deploying multiple containers within the same deployment.
+
+    pipeline:
+        deploy:
+            image: quay.io/honestbee/drone-kubernetes
+            deployment: my-deployment
+            repo: myorg/myrepo
+            container: [container1, container2]
+            tag: ${DRONE_COMMIT_SHA:8}
+
+**NOTE**: Combining multi container deployments across multiple deployments is not recommended
 
 This more complex example demonstrates how to deploy to several environments based on the branch, in a `app` namespace 
 

--- a/update.sh
+++ b/update.sh
@@ -29,9 +29,12 @@ kubectl config set-context default --cluster=default --user=default
 kubectl config use-context default
 
 # kubectl version
-IFS=',' read -r -a DEPLOYMENTS <<< "$PLUGIN_DEPLOYMENT"
+IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT}"
+IFS=',' read -r -a CONTAINERS <<< "${PLUGIN_CONTAINER}"
 for DEPLOY in ${DEPLOYMENTS[@]}; do
   echo Deploying to $KUBERNETES_SERVER
-  kubectl -n ${PLUGIN_NAMESPACE} set image deployment/${DEPLOY} \
-    ${PLUGIN_CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG}
+  for CONTAINER in ${CONTAINERS[@]}; do
+    kubectl -n ${PLUGIN_NAMESPACE} set image deployment/${DEPLOY} \
+      ${CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG}
+  done
 done


### PR DESCRIPTION
In case a single deployment is running multiple containers of the same image, I would like to simply specify a list of containers to be updated.

Tested by running `update.sh` locally without issues.