### PR TITLE
minor tweeks, extended readme

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,5 +3,4 @@ RUN apk --no-cache add curl ca-certificates bash
 RUN curl -Lo /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
 RUN chmod +x /usr/local/bin/kubectl
 COPY update.sh /bin/
-ENTRYPOINT ["/bin/bash"]
 CMD ["/bin/update.sh"]

--- a/README.md
+++ b/README.md
@@ -83,6 +83,39 @@ This more complex example demonstrates how to deploy to several environments bas
                 branch: [ master ]
 ```
 
+## Debuging
+
+For debugging you firstly need to know if the kubectl inside the container is connecting to your cluster or not.
+Easiest way to find this out to compare your [local kubectl config](https://kubernetes.io/docs/tasks/tools/install-kubectl/) `~/.kube/config` file with the generated one.
+
+The generated kube conf will be
+```yaml
+    apiVersion: v1
+    clusters:
+    - cluster:
+        server: ${kubernetes_server}
+        #possible insecure-skip-tls-verify: true or cert settings
+      name: default
+    contexts:
+    - context:
+        cluster: default
+        user: ${kubernetes_user}
+      name: default
+    current-context: default
+    kind: Config
+    preferences: {}
+    users:
+    - name: ${kubernetes_user}
+      user:
+        token: ${kubernetes_token}
+```
+
+After that the script calls the following script for every deployment+container combination:
+```bash
+kubectl -n ${namespace} set image deployment/${deployment} \
+  ${container}=${repo}:${tag}
+```
+
 ## Required secrets
 
 ```bash
@@ -98,6 +131,7 @@ This more complex example demonstrates how to deploy to several environments bas
 
 When using TLS Verification, ensure Server Certificate used by kubernetes API server 
 is signed for SERVER url ( could be a reason for failures if using aliases of kubernetes cluster )
+If you have valid ssl, you can use the `kubernetes_skip_insecure: true` flag too.
 
 ## How to get token
 1. After deployment inspect you pod for name of (k8s) secret with **token** and **ca.crt**

--- a/update.sh
+++ b/update.sh
@@ -20,10 +20,12 @@ if [ ! -z ${PLUGIN_KUBERNETES_CERT} ]; then
   KUBERNETES_CERT=${PLUGIN_KUBERNETES_CERT}
 fi
 
-kubectl config set-credentials default --token=${KUBERNETES_TOKEN}
+kubectl config set-credentials ${PLUGIN_KUBERNETES_USER} --token=${KUBERNETES_TOKEN}
 if [ ! -z ${KUBERNETES_CERT} ]; then
   echo ${KUBERNETES_CERT} | base64 -d > ca.crt
   kubectl config set-cluster default --server=${KUBERNETES_SERVER} --certificate-authority=ca.crt
+elif [ ! -z ${PLUGIN_KUBERNETES_SKIP_INSECURE} ]; then
+  kubectl config set-cluster default --server=${KUBERNETES_SERVER}
 else
   echo "WARNING: Using insecure connection to cluster"
   kubectl config set-cluster default --server=${KUBERNETES_SERVER} --insecure-skip-tls-verify=true


### PR DESCRIPTION
I removed the entry point bcs `docker run -it quay.io/honestbee/drone-kubernetes bash` didn't worked.
Fixed the user insertion.
Added a new flag to skip insecure insert. (If you have valid https you are secure, and not need to add certs.)
Added some readme so maybe the next newbie (like me) will not waste an hour to figure out what happening in the background :P