### PR TITLE
Fix root home dir being read only

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+set -e
+
+export KUBECONFIG=/tmp/kubeconfig
+
 if [ -z ${PLUGIN_NAMESPACE} ]; then
   PLUGIN_NAMESPACE="default"
 fi

--- a/update.sh
+++ b/update.sh
@@ -1,52 +1,70 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
 export KUBECONFIG=/tmp/kubeconfig
 
-if [ -z ${PLUGIN_NAMESPACE} ]; then
+if [ -z "${PLUGIN_KUBERNETES_TOKEN:-}" ]; then
+  echo "ERROR: You must set 'kubernetes_token'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_TAG:-}" ]; then
+  echo "ERROR: You must set 'tag'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_REPO:-}" ]; then
+  echo "ERROR: You must set 'repo'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_KUBERNETES_SERVER:-}" ]; then
+  echo "ERROR: You must set 'kubernetes_server'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_DEPLOYMENT:-}" ]; then
+  echo "ERROR: You must set 'deployment'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_CONTAINER:-}" ]; then
+  echo "ERROR: You must set 'container'"
+  exit 1
+fi
+
+if [ -z "${PLUGIN_NAMESPACE:-}" ]; then
   PLUGIN_NAMESPACE="default"
 fi
 
-if [ -z ${PLUGIN_KUBERNETES_USER} ]; then
+if [ -z "${PLUGIN_KUBERNETES_USER:-}" ]; then
   PLUGIN_KUBERNETES_USER="default"
 fi
 
-if [ ! -z ${PLUGIN_KUBERNETES_TOKEN} ]; then
-  KUBERNETES_TOKEN=$PLUGIN_KUBERNETES_TOKEN
-fi
-
-if [ ! -z ${PLUGIN_KUBERNETES_SERVER} ]; then
-  KUBERNETES_SERVER=$PLUGIN_KUBERNETES_SERVER
-fi
-
-if [ ! -z ${PLUGIN_KUBERNETES_CERT} ]; then
-  KUBERNETES_CERT=${PLUGIN_KUBERNETES_CERT}
-fi
-
-kubectl config set-credentials default --token=${KUBERNETES_TOKEN}
-if [ ! -z ${KUBERNETES_CERT} ]; then
-  echo ${KUBERNETES_CERT} | base64 -d > ca.crt
-  kubectl config set-cluster default --server=${KUBERNETES_SERVER} --certificate-authority=ca.crt
-else
+kubectl config set-credentials default --token=${PLUGIN_KUBERNETES_TOKEN}
+if [ -z "${PLUGIN_KUBERNETES_CERT:-}" ]; then
   echo "WARNING: Using insecure connection to cluster"
-  kubectl config set-cluster default --server=${KUBERNETES_SERVER} --insecure-skip-tls-verify=true
+  kubectl config set-cluster default --server=${PLUGIN_KUBERNETES_SERVER} --insecure-skip-tls-verify=true
+else
+  echo "${PLUGIN_KUBERNETES_CERT}" | base64 -d > ca.crt
+  kubectl config set-cluster default --server=${PLUGIN_KUBERNETES_SERVER} --certificate-authority=ca.crt
 fi
 
 kubectl config set-context default --cluster=default --user=${PLUGIN_KUBERNETES_USER}
 kubectl config use-context default
 
-# kubectl version
-IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT}"
-IFS=',' read -r -a CONTAINERS <<< "${PLUGIN_CONTAINER}"
+IFS=',' read -r -a DEPLOYMENTS <<< "${PLUGIN_DEPLOYMENT:-}"
+IFS=',' read -r -a CONTAINERS <<< "${PLUGIN_CONTAINER:-}"
 for DEPLOY in ${DEPLOYMENTS[@]}; do
-  echo Deploying to $KUBERNETES_SERVER
+  echo Deploying to $PLUGIN_KUBERNETES_SERVER
   for CONTAINER in ${CONTAINERS[@]}; do
-    if [[ ${PLUGIN_FORCE} == "true" ]]; then
+    if [ ${PLUGIN_FORCE:-} == "true" ]; then
+      # force changing the image by changing it to the TAG + FORCE then changing it back
       kubectl -n ${PLUGIN_NAMESPACE} set image deployment/${DEPLOY} \
-        ${CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG}FORCE
+        ${CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG:-}FORCE
     fi
     kubectl -n ${PLUGIN_NAMESPACE} set image deployment/${DEPLOY} \
-      ${CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG} --record
+      ${CONTAINER}=${PLUGIN_REPO}:${PLUGIN_TAG:-} --record
   done
 done


### PR DESCRIPTION
Using drone 1.0-rc with a .drone.yml like this:

```yaml
kind: pipeline
name: default

steps:
- name: build-image
  image: banzaicloud/drone-kaniko
  settings:
    registry: registry.example.com
    repo: registry.example.com/hello-k8s
    tags: ${DRONE_COMMIT_SHA}
    username:
      from_secret: docker-username
    password:
      from_secret: docker-password
  when:
    branch:
    - master

- name: deploy
  image: quay.io/honestbee/drone-kubernetes
  settings:
    kubernetes_server: https://kubernetes.default.svc.cluster.local
    kubernetes_cert:
      from_secret: k8s-cert
    kubernetes_token:
      from_secret: k8s-token
    deployment: hello-k8s
    repo: registry.example.com/hello-k8s
    tag: ${DRONE_COMMIT_SHA}
    container: hello-k8s    
  when:
    branch:
    - master
```

I got this error

```
error: mkdir /root/.kube: read-only file system 
```

It seems that drone maybe mounts /root as ro?   I dunno.  I made a change to set the kubectl config directory to be in /tmp and it works.