### PR TITLE
Include double brackets to avoid parser issues

### DIFF
--- a/update.sh
+++ b/update.sh
@@ -1,27 +1,27 @@
 #!/bin/bash
 
-if [ -z ${PLUGIN_NAMESPACE} ]; then
+if [[ -z ${PLUGIN_NAMESPACE} ]]; then
   PLUGIN_NAMESPACE="default"
 fi
 
-if [ -z ${PLUGIN_KUBERNETES_USER} ]; then
+if [[ -z ${PLUGIN_KUBERNETES_USER} ]]; then
   PLUGIN_KUBERNETES_USER="default"
 fi
 
-if [ ! -z ${PLUGIN_KUBERNETES_TOKEN} ]; then
+if [[ ! -z ${PLUGIN_KUBERNETES_TOKEN} ]]; then
   KUBERNETES_TOKEN=$PLUGIN_KUBERNETES_TOKEN
 fi
 
-if [ ! -z ${PLUGIN_KUBERNETES_SERVER} ]; then
+if [[ ! -z ${PLUGIN_KUBERNETES_SERVER} ]]; then
   KUBERNETES_SERVER=$PLUGIN_KUBERNETES_SERVER
 fi
 
-if [ ! -z ${PLUGIN_KUBERNETES_CERT} ]; then
+if [[ ! -z ${PLUGIN_KUBERNETES_CERT} ]]; then
   KUBERNETES_CERT=${PLUGIN_KUBERNETES_CERT}
 fi
 
 kubectl config set-credentials default --token=${KUBERNETES_TOKEN}
-if [ ! -z ${KUBERNETES_CERT} ]; then
+if [[ ! -z ${KUBERNETES_CERT} ]]; then
   echo ${KUBERNETES_CERT} | base64 -d > ca.crt
   kubectl config set-cluster default --server=${KUBERNETES_SERVER} --certificate-authority=ca.crt
 else


### PR DESCRIPTION
I am getting some errors with custom commands and direct passage of variable values:

```yaml
  deploy:
    image: quay.io/honestbee/drone-kubernetes
    environment:
      - PLUGIN_KUBERNETES_CERT="-----BEGIN CERTIFICATE-----example\n-----END CERTIFICATE-----"
      - PLUGIN_KUBERNETES_TOKEN="something"
      - PLUGIN_DEPLOYMENT=foo,bar
      - PLUGIN_CONTAINER=app
    commands:
      - grep -v src/example changes.txt &> /dev/null || exit 0
      - /bin/update.sh
```

It causes `/bin/update.sh: line 19: [: too many arguments`.